### PR TITLE
chore: update wheel of steel url in weekly meeting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/steel-weekly-meeting.md
+++ b/.github/ISSUE_TEMPLATE/steel-weekly-meeting.md
@@ -8,9 +8,7 @@ assignees: ''
 
 ### Rapid-fire Status Updates
 
-Every team member gives a 60 second TLDR on their current work, highlighting any blockers:
-- [Wheel of Steel](https://wheelofnames.com/axb-4cz).
-- [60s timer](https://www.bigtimer.net/?minutes=1&repeat=false).
+Every team member gives a 60 second TLDR on their current work, highlighting any blockers, chosen by the [Wheel of Steel](https://wheelofdeath.rip/?id=WcLWOPBC).
 
 Anything that can't be resolved within 60s should be scheduled for discussion later in the call.
 


### PR DESCRIPTION
## Summary
- Updates the Wheel of Steel URL from wheelofnames.com to wheelofdeath.rip
- Simplifies the rapid-fire status updates section by removing the separate timer link