### PR TITLE
EVM Gas Points

### DIFF
--- a/Templates/EIP-Complexity-Assessment.md
+++ b/Templates/EIP-Complexity-Assessment.md
@@ -20,7 +20,7 @@ New EVM gas accounting rules
 - 0. No gas accounting changes.
 - 1. Existing gas accounting mechanism is updated but it does not affect existing tests.
 - 2. A new gas accounting mechanism is introduced but it does not affect existing mechanisms nor does it affect existing tests.
-- 3. A gas accounting mechanism is introduced/modified and affects existing mechanisms which in turn affect existing tests.
+- 3. A gas accounting mechanism is introduced/modified and affects existing tests.
 
 ##### Blob gas accounting changes
 


### PR DESCRIPTION
I don't understand the difference between assigning 1 and 3 points here.

Imagine a change that modifies an existing gas mechanism that affects existing tests. Under the current rules, it would be assigned one point. A new mechanism doing the same would be assigned three points.

I would argue that the distinction between a new mechanism and a modification is immaterial to the complexity of a change when it requires test modifications. As an aside, new vs. modification is a very subjective criterion.

This change is one _possible_ solution. I don't necessarily believe it is the correct one.