### PR TITLE
ci: auto open/close weekly STEEL meeting issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/steel-weekly-meeting.md
+++ b/.github/ISSUE_TEMPLATE/steel-weekly-meeting.md
@@ -14,4 +14,6 @@ Anything that can't be resolved within 60s should be scheduled for discussion la
 
 ### Agenda Points
 
-TBD - please add comments to this issue for discussion in the meeting.
+- Glamsterdam
+- Hegota
+- Benchmarking

--- a/.github/workflows/weekly-meeting.yml
+++ b/.github/workflows/weekly-meeting.yml
@@ -1,0 +1,74 @@
+name: Weekly Meeting Issue
+
+on:
+  schedule:
+    # Wednesday 18:00 UTC — after the call: close this week's, open next week's
+    - cron: "0 18 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/ISSUE_TEMPLATE
+
+      - name: Close current meeting issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prev=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "STEEL Weekly Meeting in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$prev" ]; then
+            gh issue close "$prev" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment "Closed automatically after the weekly call."
+            echo "Closed issue #$prev"
+          else
+            echo "No open meeting issue found"
+          fi
+
+      - name: Compute next Wednesday date
+        id: date
+        run: |
+          next_wed=$(date -d "+7 days" +"%Y-%m-%d")
+          day=$(date -d "$next_wed" +%-d)
+
+          # Ordinal suffix
+          case "$day" in
+            1|21|31) suffix="st" ;;
+            2|22)    suffix="nd" ;;
+            3|23)    suffix="rd" ;;
+            *)       suffix="th" ;;
+          esac
+
+          month=$(date -d "$next_wed" +%B)
+          year=$(date -d "$next_wed" +%Y)
+
+          title="STEEL Weekly Meeting, Wed ${day}${suffix} ${month}, ${year}"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+
+      - name: Open next week's meeting issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.date.outputs.title }}
+        run: |
+          # Strip YAML frontmatter from the issue template
+          body=$(sed '1{/^---$/!q;};1,/^---$/d' \
+            .github/ISSUE_TEMPLATE/steel-weekly-meeting.md)
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" \
+            --label "meeting" \
+            --body "$body"


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that **closes**/**opens** a new meeting issue every Wednesday at 18:00 UTC after the call ends.
- Uses the same body/title format as the existing issue template (`STEEL Weekly Meeting, Wed 8th April, 2026`)
- Applies the `meeting` label to the issue created!
