### PR TITLE
Automate N+1 Call issue rotation

### DIFF
--- a/.github/ISSUE_TEMPLATE/n-plus-1-call.md
+++ b/.github/ISSUE_TEMPLATE/n-plus-1-call.md
@@ -1,0 +1,18 @@
+---
+name: N+1 Call
+about: Weekly call focused on changes planned for future EL forks (fork N+1)
+title: "N+1 Call, Friday <date>"
+labels: meeting
+assignees: ''
+---
+
+### About the call
+
+Cadence: Weekly, Friday @ 2pm UTC
+Lead: @petertdavies
+Link: https://meet.google.com/kcz-xrug-dyy
+
+This is a new call to provide a space to focus on the changes planned for future forks on the EL. The goal is to get ahead of the game and be ready when the rest of the development process rolls forward from fork N to fork N+1.
+
+### Agenda
+- 

--- a/.github/workflows/n-plus-1-call.yml
+++ b/.github/workflows/n-plus-1-call.yml
@@ -1,0 +1,74 @@
+name: N+1 Call Issue
+
+on:
+  schedule:
+    # Friday 16:00 UTC — after the 14:00 UTC call: close this week's, open next week's
+    - cron: "0 16 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/ISSUE_TEMPLATE
+
+      - name: Close current call issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prev=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "N+1 Call in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$prev" ]; then
+            gh issue close "$prev" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment "Closed automatically after the N+1 call."
+            echo "Closed issue #$prev"
+          else
+            echo "No open call issue found"
+          fi
+
+      - name: Compute next Friday date
+        id: date
+        run: |
+          next_fri=$(date -d "+7 days" +"%Y-%m-%d")
+          day=$(date -d "$next_fri" +%-d)
+
+          # Ordinal suffix
+          case "$day" in
+            1|21|31) suffix="st" ;;
+            2|22)    suffix="nd" ;;
+            3|23)    suffix="rd" ;;
+            *)       suffix="th" ;;
+          esac
+
+          month=$(date -d "$next_fri" +%B)
+          year=$(date -d "$next_fri" +%Y)
+
+          title="N+1 Call, Friday ${day}${suffix} ${month} ${year}"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+
+      - name: Open next week's call issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.date.outputs.title }}
+        run: |
+          # Strip YAML frontmatter from the issue template
+          body=$(sed '1{/^---$/!q;};1,/^---$/d' \
+            .github/ISSUE_TEMPLATE/n-plus-1-call.md)
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" \
+            --label "meeting" \
+            --body "$body"


### PR DESCRIPTION
Mirrors the STEEL Weekly Meeting automation for the **N+1 Call** (weekly, Friday 14:00 UTC, lead @petertdavies).

### What it does
A new workflow runs every Friday at **16:00 UTC** (after the call) and:
1. Closes the open `N+1 Call` issue (matched by `N+1 Call in:title`, so it never touches the STEEL issue), leaving an auto-close comment.
2. Computes next Friday's date and opens a fresh issue from the template.

Also triggerable manually via `workflow_dispatch`.

### Files
- `.github/workflows/n-plus-1-call.yml` — the rotation workflow (parallel to `weekly-meeting.yml`).
- `.github/ISSUE_TEMPLATE/n-plus-1-call.md` — "About the call" boilerplate + empty agenda.

### Notes
- Title format matches the existing N+1 issues exactly: `N+1 Call, Friday 5th June 2026`.
- Adds the `meeting` label to new issues (consistent with STEEL); recent N+1 issues were unlabeled.
- To verify before the first scheduled run: trigger `workflow_dispatch` once it's on `main` — note that doing so will close the current open issue (#74) and open next week's.