### PR TITLE
chore(ci): rename steel references to specs

### DIFF
--- a/.github/ISSUE_TEMPLATE/specs-weekly-meeting.md
+++ b/.github/ISSUE_TEMPLATE/specs-weekly-meeting.md
@@ -1,14 +1,14 @@
 ---
-name: STEEL Weekly Meeting
+name: SPECS Weekly Meeting
 about: Weekly team sync meeting agenda
-title: "STEEL Weekly Meeting, Wed <date>"
+title: "SPECS Weekly Meeting, Wed <date>"
 labels: meeting
 assignees: ''
 ---
 
 ### Rapid-fire Status Updates
 
-Every team member gives a 60 second TLDR on their current work, highlighting any blockers, chosen by the [Wheel of Steel](https://wheelofdeath.rip/?id=WcLWOPBC).
+Every team member gives a 60 second TLDR on their current work, highlighting any blockers, chosen by the [Wheel of Specs](https://wheelofdeath.rip/?id=WcLWOPBC).
 
 Anything that can't be resolved within 60s should be scheduled for discussion later in the call.
 

--- a/.github/workflows/weekly-meeting.yml
+++ b/.github/workflows/weekly-meeting.yml
@@ -25,7 +25,7 @@ jobs:
           prev=$(gh issue list \
             --repo "$GITHUB_REPOSITORY" \
             --state open \
-            --search "STEEL Weekly Meeting in:title" \
+            --search "SPECS Weekly Meeting in:title" \
             --json number \
             --jq '.[0].number // empty')
 
@@ -55,7 +55,7 @@ jobs:
           month=$(date -d "$next_wed" +%B)
           year=$(date -d "$next_wed" +%Y)
 
-          title="STEEL Weekly Meeting, Wed ${day}${suffix} ${month}, ${year}"
+          title="SPECS Weekly Meeting, Wed ${day}${suffix} ${month}, ${year}"
           echo "title=$title" >> "$GITHUB_OUTPUT"
 
       - name: Open next week's meeting issue
@@ -65,7 +65,7 @@ jobs:
         run: |
           # Strip YAML frontmatter from the issue template
           body=$(sed '1{/^---$/!q;};1,/^---$/d' \
-            .github/ISSUE_TEMPLATE/steel-weekly-meeting.md)
+            .github/ISSUE_TEMPLATE/specs-weekly-meeting.md)
 
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # pm
-Ethereum STEEL Project Management
+Ethereum SPECS Project Management


### PR DESCRIPTION
## Summary

Renames the team name from STEEL to SPECS, following the org rename (`ethsteel` → `ethspecs`):

- Team name in `README.md` and the weekly meeting issue template + workflow
- Issue template file renamed: `steel-weekly-meeting.md` → `specs-weekly-meeting.md` (workflow reference updated to match)
- "Wheel of Steel" → "Wheel of Specs" in the meeting template (link unchanged)

**Monthly summaries are left completely untouched** as a historical record (team name, recap titles, and `steel.ethereum.foundation` links all preserved).

Note: the `steel` refs in the call-reminder files (`.github/calls.yml`, `.github/scripts/call_reminder.py`) live on the unmerged `call-reminder-bot` branch, so they were renamed there instead (see #77).