### PR TITLE
Add EL Spec Call agenda automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/el-spec-call.md
+++ b/.github/ISSUE_TEMPLATE/el-spec-call.md
@@ -1,0 +1,17 @@
+---
+name: EL Spec Call
+about: Weekly EL spec call agenda
+title: "EL Spec Call, Wed <date>"
+labels: meeting
+assignees: ''
+---
+
+### About the call
+
+Cadence: Weekly, Wednesday @ REPLACE_TIME UTC
+Lead: REPLACE_LEAD
+Link: REPLACE_MEETING_LINK
+
+### Agenda
+
+- 

--- a/.github/ISSUE_TEMPLATE/el-spec-call.md
+++ b/.github/ISSUE_TEMPLATE/el-spec-call.md
@@ -15,10 +15,20 @@ Link: REPLACE_MEETING_LINK
 This issue covers both of this week's EL spec calls. It is opened automatically
 after Thursday's call and closed after the following Thursday's call.
 
-### Tuesday Agenda
+### Rapid-fire Status Updates
 
-- 
+Every team member gives a 60 second TLDR on their current work, highlighting any blockers, chosen by the [Wheel of Specs](https://wheelofdeath.rip/?id=WcLWOPBC).
 
-### Thursday Agenda
+Anything that can't be resolved within 60s should be scheduled for discussion later in the call.
 
-- 
+### Tuesday Agenda Points
+
+- Glamsterdam
+- Hegota
+- Benchmarking
+
+### Thursday Agenda Points
+
+- Glamsterdam
+- Hegota
+- Benchmarking

--- a/.github/ISSUE_TEMPLATE/el-spec-call.md
+++ b/.github/ISSUE_TEMPLATE/el-spec-call.md
@@ -1,17 +1,24 @@
 ---
 name: EL Spec Call
-about: Weekly EL spec call agenda
-title: "EL Spec Call, Wed <date>"
+about: Agenda for the twice-weekly EL spec calls (Tuesday & Thursday)
+title: "EL Spec Call, Tue <date> & Thu <date>"
 labels: meeting
 assignees: ''
 ---
 
-### About the call
+### About the calls
 
-Cadence: Weekly, Wednesday @ REPLACE_TIME UTC
+Cadence: Twice weekly, Tuesday & Thursday @ REPLACE_TIME UK time
 Lead: REPLACE_LEAD
 Link: REPLACE_MEETING_LINK
 
-### Agenda
+This issue covers both of this week's EL spec calls. It is opened automatically
+after Thursday's call and closed after the following Thursday's call.
+
+### Tuesday Agenda
+
+- 
+
+### Thursday Agenda
 
 - 

--- a/.github/workflows/el-spec-call.yml
+++ b/.github/workflows/el-spec-call.yml
@@ -2,8 +2,9 @@ name: EL Spec Call Issue
 
 on:
   schedule:
-    # Wednesday 18:00 UTC — after the call: close this week's, open next week's
-    - cron: "0 18 * * 3"
+    # Thursday 17:00 UTC = 5pm UK in winter (6pm in summer) — after Thursday's
+    # call: close this week's issue (Tue & Thu), open next week's
+    - cron: "0 17 * * 4"
   workflow_dispatch:
 
 permissions:
@@ -32,30 +33,35 @@ jobs:
           if [ -n "$prev" ]; then
             gh issue close "$prev" \
               --repo "$GITHUB_REPOSITORY" \
-              --comment "Closed automatically after the EL spec call."
+              --comment "Closed automatically after Thursday's EL spec call."
             echo "Closed issue #$prev"
           else
             echo "No open call issue found"
           fi
 
-      - name: Compute next Wednesday date
+      - name: Compute next Tuesday and Thursday dates
         id: date
         run: |
-          next_wed=$(date -d "+7 days" +"%Y-%m-%d")
-          day=$(date -d "$next_wed" +%-d)
-
           # Ordinal suffix
-          case "$day" in
-            1|21|31) suffix="st" ;;
-            2|22)    suffix="nd" ;;
-            3|23)    suffix="rd" ;;
-            *)       suffix="th" ;;
-          esac
+          ordinal() {
+            case "$1" in
+              1|21|31) echo "st" ;;
+              2|22)    echo "nd" ;;
+              3|23)    echo "rd" ;;
+              *)       echo "th" ;;
+            esac
+          }
 
-          month=$(date -d "$next_wed" +%B)
-          year=$(date -d "$next_wed" +%Y)
+          next_tue=$(date -d "next tuesday" +"%Y-%m-%d")
+          next_thu=$(date -d "next thursday" +"%Y-%m-%d")
 
-          title="EL Spec Call, Wed ${day}${suffix} ${month}, ${year}"
+          tue_day=$(date -d "$next_tue" +%-d)
+          tue_month=$(date -d "$next_tue" +%B)
+          thu_day=$(date -d "$next_thu" +%-d)
+          thu_month=$(date -d "$next_thu" +%B)
+          year=$(date -d "$next_thu" +%Y)
+
+          title="EL Spec Call, Tue ${tue_day}$(ordinal "$tue_day") ${tue_month} & Thu ${thu_day}$(ordinal "$thu_day") ${thu_month}, ${year}"
           echo "title=$title" >> "$GITHUB_OUTPUT"
 
       - name: Open next week's call issue

--- a/.github/workflows/el-spec-call.yml
+++ b/.github/workflows/el-spec-call.yml
@@ -1,0 +1,74 @@
+name: EL Spec Call Issue
+
+on:
+  schedule:
+    # Wednesday 18:00 UTC — after the call: close this week's, open next week's
+    - cron: "0 18 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/ISSUE_TEMPLATE
+
+      - name: Close current call issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prev=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --search "EL Spec Call in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$prev" ]; then
+            gh issue close "$prev" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment "Closed automatically after the EL spec call."
+            echo "Closed issue #$prev"
+          else
+            echo "No open call issue found"
+          fi
+
+      - name: Compute next Wednesday date
+        id: date
+        run: |
+          next_wed=$(date -d "+7 days" +"%Y-%m-%d")
+          day=$(date -d "$next_wed" +%-d)
+
+          # Ordinal suffix
+          case "$day" in
+            1|21|31) suffix="st" ;;
+            2|22)    suffix="nd" ;;
+            3|23)    suffix="rd" ;;
+            *)       suffix="th" ;;
+          esac
+
+          month=$(date -d "$next_wed" +%B)
+          year=$(date -d "$next_wed" +%Y)
+
+          title="EL Spec Call, Wed ${day}${suffix} ${month}, ${year}"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+
+      - name: Open next week's call issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.date.outputs.title }}
+        run: |
+          # Strip YAML frontmatter from the issue template
+          body=$(sed '1{/^---$/!q;};1,/^---$/d' \
+            .github/ISSUE_TEMPLATE/el-spec-call.md)
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" \
+            --label "meeting" \
+            --body "$body"


### PR DESCRIPTION
## Summary

Adds agenda-issue automation for the new **EL Spec Call**, which runs **twice weekly: Tuesday & Thursday**. Copied from the SPECS weekly meeting automation (same rotate pattern as the N+1 call, #75).

**One issue covers both of the week's calls.** The template includes the rapid-fire status updates section (60s TLDRs picked by the Wheel of Specs) and separate Tuesday/Thursday agenda sections seeded with the initial points from the weekly meeting agenda (Glamsterdam, Hegota, Benchmarking).

The rotation runs **after Thursday's call at 5pm UK** (cron `0 17 * * 4`, i.e. 17:00 UTC = 5pm UK in winter, 6pm in summer):

- close this week's issue (both calls done)
- open next week's issue titled e.g. `EL Spec Call, Tue 14th July & Thu 16th July, 2026` (handles month boundaries: `Tue 30th June & Thu 2nd July, 2026`)

Files:
- `.github/ISSUE_TEMPLATE/el-spec-call.md` — agenda issue template
- `.github/workflows/el-spec-call.yml` — Thursday-evening rotation workflow

## Placeholders to fill in before merging

- `REPLACE_TIME` (call time), `REPLACE_LEAD`, `REPLACE_MEETING_LINK` in the template